### PR TITLE
Feature/174 enriching unesco

### DIFF
--- a/data-integration/extract_contributor_correlation.py
+++ b/data-integration/extract_contributor_correlation.py
@@ -1,0 +1,84 @@
+#
+# (c) 2022 Sven Lieber
+# KBR Brussels
+#
+import csv
+from optparse import OptionParser
+import utils_string
+import utils
+
+
+# -----------------------------------------------------------------------------
+def checkArguments():
+  parser = OptionParser(usage="usage: %prog [options]")
+  parser.add_option('-i', '--input', action='store', help='Input CSV file')
+  parser.add_option('-o', '--output', action='store', help='Second CSV file')
+  parser.add_option('--output-column', action='append', help='The name of a column which should be included in the output')
+  parser.add_option('--column', action='store',
+                    help='column name of the CSV in which it is checked for missing contributor overlap')
+  parser.add_option('--csv-delimiter', action='store', default=',', help='Delimiter of the input CSV, default is a comma')
+  parser.add_option('--column-value-delimiter', action='store', default=';', help='Delimiter used within a column to separate different names we want to compare')
+
+  (options, args) = parser.parse_args()
+
+  if (not options.input) or (not options.output) or (not options.column) or (not options.output_column):
+    print(f'Input and output data as well as a column name are needed')
+    parser.print_help()
+    exit(1)
+
+  return options, args
+   
+# -----------------------------------------------------------------------------
+def main(inputFile, outputFile, outputColumns, columnName, csvDelimiter, columnValueDelimiter):
+  """This script reads a CSV files and checks if parts of the value in a given column occur more than once in the column.
+     For example "Sven Lieber (int1: abc, def); Lieber, Sven (int2: abc)" where the first name but also the last name occur twice."""
+
+  with open(inputFile, 'r') as inFile, \
+       open(outputFile, 'w') as outFile:
+
+    inputReader = csv.DictReader(inFile, delimiter=csvDelimiter)
+
+    wantedColumns = outputColumns + [columnName]
+    utils.checkIfColumnsExist(inputReader.fieldnames, wantedColumns)
+
+    outputWriter = csv.DictWriter(outFile, fieldnames=wantedColumns, delimiter=csvDelimiter)
+
+    identifiers = set()
+    numberRows = 0
+    numberFound = 0
+    outputWriter.writeheader()
+
+    contributorLookup = ContributorLookup()
+    possibleMatches = []
+
+    for row in inputReader:
+
+      contributorIdentifiersOfThisRow = []
+      columnValue = row[columnName]
+      # we may have "name1 (intID1: id1, idn) ; name2 (intID2: id2, idn)" and split in this example by ';' to treat each name-ids combination seperately
+      values = columnValue.split(columnValueDelimiter)
+
+      if len(values) > 1:
+        valueNameParts = []
+        for value in values:
+          contributorID = contributorLookup.addContributor(value)
+          contributorIdentifiersOfThisRow.append(contributorID)
+        posssibleMatchesInThisRow = contributorLookup.getPossibleMatches(contributorIdentifiersOfThisRow)
+        if possibleMatchesInThisRow:
+          possibleMatches.append(possibleMatchesInThisRow)
+
+#    for possibleMatch in possibleMatches.getMatches():
+#      outputRow = possibleMatch.getRow()
+#        if utils_string.overlappingValues(valueNameParts):
+#          numberFound += 1
+#          # adding all wanted columns to the output
+#          outputRow = {key: row[key] for key in wantedColumns}
+#          outputWriter.writerow(outputRow)
+#      numberRows += 1
+#
+#    print(f'{numberFound}/{numberRows} contain possible contributor duplicates.')
+
+if __name__ == '__main__':
+  (options, args) = checkArguments()
+  main(options.input, options.output, options.output_column, options.column, options.csv_delimiter, options.column_value_delimiter)
+

--- a/data-integration/identify_duplicate_contributors.py
+++ b/data-integration/identify_duplicate_contributors.py
@@ -38,10 +38,10 @@ def main(inputFile, outputFile, outputColumns, columnName, csvDelimiter, columnV
 
     inputReader = csv.DictReader(inFile, delimiter=csvDelimiter)
 
-    utils.checkIfColumnsExist(inputReader.fieldnames, outputColumns + [columnName])
+    wantedColumns = outputColumns + [columnName]
+    utils.checkIfColumnsExist(inputReader.fieldnames, wantedColumns)
 
-    # not using list(wantedColumns) as fieldnames because we want to determine the order
-    outputWriter = csv.DictWriter(outFile, fieldnames=outputColumns + [columnName], delimiter=csvDelimiter)
+    outputWriter = csv.DictWriter(outFile, fieldnames=wantedColumns, delimiter=csvDelimiter)
 
     identifiers = set()
     numberRows = 0

--- a/data-integration/integrated_contributors.py
+++ b/data-integration/integrated_contributors.py
@@ -1,0 +1,238 @@
+import utils_string
+from itertools import combinations
+
+# -----------------------------------------------------------------------------
+class ContributorLookup():
+
+  # ---------------------------------------------------------------------------
+  def __init__(self, integratedIdentifierDelimiter=':', localIdentifierDelimiter=','):
+    self.contributors = {}
+    self.possibleMatches = []
+    self.correlations = []
+    self.localIdentifierNames = set()
+
+    self.integratedIdentifierDelimiter = integratedIdentifierDelimiter
+    self.localIdentifierDelimiter = localIdentifierDelimiter
+
+  # ---------------------------------------------------------------------------
+  def addContributor(self, contributorString):
+    """This method extracts contributor data from the given string.
+    >>> c = ContributorLookup()
+    >>> c.addContributor("Sven Lieber (int123: 123, cb123, p123)")
+    'int123'
+    >>> dict(sorted(c.getContributor('int123').items()))
+    {'BnF': 'cb123', 'KBR': '123', 'NTA': 'p123', 'name': 'Sven Lieber'}
+    """
+
+    # split name from the list of identifiers
+    # we use rpartition instead of split,
+    # because the name might include a bracket too,
+    # example: "Davidsfonds (Leuven) (1234: kbr123, bnf123)"
+    nameIDParts = contributorString.rpartition('(')
+    contributorName = nameIDParts[0].strip()
+
+    # split the unique identifier from the local identifiers
+    # nameIDParts[1] is the delimiter itself
+    identifiersString = nameIDParts[2].split(')')[0]
+
+    identifierParts = identifiersString.split(self.integratedIdentifierDelimiter)
+
+    # get the unique identifier
+    contributorID = identifierParts[0].strip()
+    localIdentifiers = identifierParts[1]
+
+    localIdentifierParts = localIdentifiers.split(self.localIdentifierDelimiter)
+
+    # add the local identifiers if we have not yet seen this contributor
+    if contributorID not in self.contributors:
+      self.contributors[contributorID] = {'name': contributorName}
+
+      for localIdentifier in localIdentifierParts:
+        localIdentifier = localIdentifier.strip()
+        if localIdentifier.startswith('cb'):
+          self.localIdentifierNames.add('BnF')
+          self.contributors[contributorID]['BnF'] = localIdentifier
+        elif localIdentifier.startswith('p'):
+          self.localIdentifierNames.add('NTA')
+          self.contributors[contributorID]['NTA'] = localIdentifier
+        elif localIdentifier.startswith('u'):
+          self.localIdentifierNames.add('Unesco')
+          self.contributors[contributorID]['Unesco'] = localIdentifier
+        else:
+          self.localIdentifierNames.add('KBR')
+          self.contributors[contributorID]['KBR'] = localIdentifier
+
+    return contributorID
+    
+  # ---------------------------------------------------------------------------
+  def computePossibleMatches(self, contributorIdentifiers):
+    """This method takes a list of contributor identifiers and returns a set with the contributor identifiers who share at least one normalized name component.
+    >>> c = ContributorLookup()
+
+    Add the first author with unique identifier int123 who has a KBR and a BnF identifier
+    >>> c.addContributor("Sven Lieber (int123: 123, cb123)")
+    'int123'
+
+    Add a second author with unique identifier int456 who has a Unesco identifier
+    >>> c.addContributor("Lieber, Sven (int456: u123)")
+    'int456'
+
+    Add more authors ...
+    >>> c.addContributor("John Johnsson (int789: 789, cb789)")
+    'int789'
+
+    >>> c.addContributor("Lieber, S. (int10: p10)")
+    'int10'
+
+    The call to this method determines that all three Sven's might be the same
+    >>> sorted(c.computePossibleMatches(['int123', 'int456', 'int789', 'int10']))
+    ['int10', 'int123', 'int456']
+    """ 
+
+    # create a lookup list with the contributor ID as key
+    # and a set of normalized name components as values
+    lookup = {}
+    for cID in contributorIdentifiers:
+      lookupValues = set()
+      if cID in self.contributors:
+        parts = self.contributors[cID]['name'].replace(',', ' ' ).split(' ')
+        for p in parts:
+          namePart = utils_string.getNormalizedString(p).strip()
+          if namePart != '':
+            lookupValues.add(namePart)
+        lookup[cID] = lookupValues
+
+    # determine possible contributor overlap
+    # by performing an intersection between the name components:
+    # if at least one of the components overlap, add it to the result set
+    possibleMatch = set()
+    for i in combinations(lookup, 2):
+      if set.intersection(lookup[i[0]], lookup[i[1]]):
+        possibleMatch.add(i[0])
+        possibleMatch.add(i[1])
+
+    self.possibleMatches.append(possibleMatch)
+    return possibleMatch
+
+  # ---------------------------------------------------------------------------
+  def computeCorrelations(self):
+    """This method creates a list of unique sets with all found correlations by looping over possible matches.
+    >>> c = ContributorLookup()
+
+    Some sets are indirectly linked because they share an identifier.
+    This function aims to link those sets and return the minimum set of correlations
+    >>> c.possibleMatches = [{'123', '456'}, {'123', '789'}, {'456', '789'}, {'789', '10'}, {'111', '222'}, {'1', '3'}, {'3', '4'}]
+    >>> c.computeCorrelations()
+    >>> [sorted(s) for s in c.correlations]
+    [['10', '123', '456', '789'], ['111', '222'], ['1', '3', '4']]
+    """
+
+    matchesDictionary = {}
+
+    # create a dictionary with contributor identifiers as key
+    # and all direct found matches as value represented as a set
+    # (this set also contains the contributor ID of the key)
+    # For example: {'123': {'456', '123', '789'}
+    for possibleMatchSet in self.possibleMatches:
+      for contID in possibleMatchSet:
+        if contID in matchesDictionary:
+          matchesDictionary[contID].update(possibleMatchSet)
+        else:
+          matchesDictionary[contID] = possibleMatchSet
+
+    # create unique sets of contributor identifiers
+    # which are also linked indirectly
+    alreadyProcessed = set()
+    for cID in matchesDictionary:
+
+      # if the current ID was already processed as value of another cID
+      # we do not need to process it again, it will already be part of the output
+      if cID in alreadyProcessed:
+        continue
+
+      # fetch all matches of all the identifiers in the current set
+      # the current cID is also part of its values, so no need to add it separately
+      currentMatchSet = matchesDictionary[cID]
+      relatedMatches = set()
+      for matchID in currentMatchSet:
+        alreadyProcessed.add(matchID)
+        relatedMatches.add(matchID)
+
+        # for each possibleMatch identifier, get its possible matches
+        if matchID in matchesDictionary:
+          otherMatchSet = matchesDictionary[matchID]
+          alreadyProcessed.update(otherMatchSet)
+          relatedMatches.update(otherMatchSet)
+
+      self.correlations.append(relatedMatches)
+
+  # ---------------------------------------------------------------------------
+  def getCorrelationsLocalIdentifiers(self):
+    """This method computes correlation based on possible matches and returns linked local identifiers.
+    >>> c = ContributorLookup()
+
+    Add the first author with unique identifier int123 who has a KBR and a BnF identifier
+    >>> c.addContributor("Sven Lieber (int123: 123, cb123)")
+    'int123'
+
+    Add a second author with unique identifier int456 who has a Unesco identifier
+    >>> c.addContributor("Lieber, Sven (int456: u123)")
+    'int456'
+
+    Add more authors ...
+    >>> c.addContributor("John Johnsson (int789: 789, cb789)")
+    'int789'
+
+    >>> c.addContributor("Lieber, S. (int10: 123x, p10)")
+    'int10'
+
+    Imagine we have seen the following 4 authors for the same publication, check the overlap
+    >>> sorted(c.computePossibleMatches(['int123', 'int456', 'int789', 'int10']))
+    ['int10', 'int123', 'int456']
+
+    Get the first item which is returned by this generator function
+    >>> dict(sorted(next(c.getCorrelationsLocalIdentifiers()).items()))
+    {'BnF': 'cb123', 'KBR': '123;123x', 'NTA': 'p10', 'Unesco': 'u123'}
+    """
+
+    # first compute correlations which will be stored in self.correlations
+    self.computeCorrelations()
+
+    for correlationSet in self.correlations:
+      outputRow = {}
+      localIdentifiers = {}
+      for cID in correlationSet:
+        if cID in self.contributors:
+          currentLocalIdentifiers = self.contributors[cID]
+          #currentLocalIdentifiers = {key: value for key, value in self.contributors[cID].items() if key != 'name'}
+
+          # merge current local identifiers to the rest
+          # we do not simply use the dictionary update method, 
+          # because we do not want to overwrite possible already existing identifiers
+          # but add others of the same type using a semicolon
+          for l in currentLocalIdentifiers:
+            if l in localIdentifiers:
+              # create a sorted list of identifiers from this type
+              # serialized as a semicolon-separated list
+              currentValue = localIdentifiers[l]
+              newValue = [currentValue] + currentLocalIdentifiers[l].split(';')
+              localIdentifiers[l] = ';'.join(sorted(newValue))
+            else:
+              localIdentifiers[l] = currentLocalIdentifiers[l]
+      yield localIdentifiers
+
+  # ---------------------------------------------------------------------------
+  def getContributor(self, contributorID):
+    if contributorID in self.contributors:
+      return self.contributors[contributorID]
+    else:
+      return None
+
+  # ---------------------------------------------------------------------------
+  def getLocalIdentifierNames(self):
+    return list(self.localIdentifierNames)
+
+# -----------------------------------------------------------------------------
+if __name__ == "__main__":
+  import doctest
+  doctest.testmod()

--- a/data-integration/sparql-queries/get-author-overlap.sparql
+++ b/data-integration/sparql-queries/get-author-overlap.sparql
@@ -1,0 +1,94 @@
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix prov: <http://www.w3.org/ns/prov#>
+prefix dc: <http://purl.org/dc/elements/1.1/>
+prefix dcterms: <http://purl.org/dc/terms/>
+prefix schema: <http://schema.org/>
+prefix bibo: <http://purl.org/ontology/bibo/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX btm: <http://kbr.be/ns/beltrans/model#>
+PREFIX btid: <http://kbr.be/id/data/> 
+PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
+PREFIX btisni: <http://kbr.be/isni/>
+PREFIX mads: <http://www.loc.gov/mads/rdf/v1#>
+PREFIX up: <http://users.ugent.be/~tdenies/up/>
+PREFIX marcrel: <http://id.loc.gov/vocabulary/relators/> 
+PREFIX rdagroup1elements: <http://rdvocab.info/Elements/>
+PREFIX rdagroup2elements: <http://rdvocab.info/ElementsGr2/>
+
+
+SELECT
+  ?manifestationID
+    (group_concat(distinct ?authorNameID;SEPARATOR=';') AS ?authors)
+    (group_concat(distinct ?kbrNameID;SEPARATOR=';') AS ?kbrNames)
+    (group_concat(distinct ?bnfNameID;SEPARATOR=';') AS ?bnfNames)
+    (group_concat(distinct ?ntaNameID;SEPARATOR=';') AS ?ntaNames)
+    (group_concat(distinct ?unescoNameID;SEPARATOR=';') AS ?unescoNames)
+WHERE {
+
+  graph <http://beltrans-manifestations> {
+    ?manifestation a schema:CreativeWork ;
+                   dcterms:identifier ?manifestationID ;
+                   schema:isPartOf btid:beltransCorpus .
+  }
+
+  # AUTHOR
+  #
+  OPTIONAL {
+    graph <http://beltrans-manifestations> { ?manifestation schema:author ?author . }
+    OPTIONAL {
+      graph <http://beltrans-contributors> { ?author rdfs:label ?authorLabel . } 
+      BIND(REPLACE(?authorLabel, ";", "", "i") AS ?authorLabelNorm)
+    }
+
+    BIND(CONCAT( COALESCE(?authorLabelNorm, "missing name"), " (", ?authorID, ": ", ?authorIdentifiers, ")") as ?authorNameID)
+    # This subquery retrieves the local identifiers of the author
+    {
+      SELECT DISTINCT ?manifestation ?author ?authorID (group_concat(distinct ?authorLocalIdentifier;SEPARATOR=',') as ?authorIdentifiers)
+      WHERE { 
+        graph <http://beltrans-manifestations> {
+          ?manifestation schema:name ?title ;
+                         schema:author ?author .
+        }    
+        ?author dcterms:identifier ?authorID .
+        ?author schema:sameAs/dcterms:identifier ?authorLocalIdentifier . 
+      }
+      GROUP BY ?manifestation ?author ?authorID
+    }
+
+    OPTIONAL {
+      graph <http://beltrans-contributors> { ?author schema:sameAs ?kbrURI . }
+      graph <http://kbr-linked-authorities> { ?kbrURI dcterms:identifier ?kbrID . }
+      graph <http://kbr-linked-authorities> { ?kbrURI rdfs:label|skos:prefLabel ?kbrName . }
+
+      BIND( CONCAT(?kbrName, ' (', ?kbrID, ')') AS ?kbrNameID)
+    }
+
+    OPTIONAL {
+      graph <http://beltrans-contributors> { ?author schema:sameAs ?bnfURI . }
+      graph <http://bnf-contributors> { ?bnfURI dcterms:identifier ?bnfID . }
+      graph <http://bnf-contributors> { ?bnfURI foaf:name ?bnfName . }
+
+      BIND( CONCAT(?bnfName, ' (', ?bnfID, ')') AS ?bnfNameID)
+    }
+
+    OPTIONAL {
+      graph <http://beltrans-contributors> { ?author schema:sameAs ?ntaURI . }
+      graph <http://kb-linked-authorities> { ?ntaURI dcterms:identifier ?ntaID . }
+      graph <http://kb-linked-authorities> { ?ntaURI schema:name ?ntaName . }
+
+      BIND( CONCAT(?ntaName, ' (', ?ntaID, ')') AS ?ntaNameID)
+    }
+
+    OPTIONAL {
+      graph <http://beltrans-contributors> { ?author schema:sameAs ?unescoURI . }
+      graph <http://unesco-linked-authorities> { ?unescoURI dcterms:identifier ?unescoID . }
+      graph <http://unesco-linked-authorities> { ?unescoURI rdfs:label ?unescoName . }
+
+      BIND( CONCAT(?unescoName, ' (', ?unescoID, ')') AS ?unescoNameID)
+    }
+
+  }
+}
+GROUP BY ?manifestationID
+HAVING(count(?author) > 1)

--- a/data-integration/sparql-queries/get-contributor-overlap.sparql
+++ b/data-integration/sparql-queries/get-contributor-overlap.sparql
@@ -1,0 +1,90 @@
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix prov: <http://www.w3.org/ns/prov#>
+prefix dc: <http://purl.org/dc/elements/1.1/>
+prefix dcterms: <http://purl.org/dc/terms/>
+prefix schema: <http://schema.org/>
+prefix bibo: <http://purl.org/ontology/bibo/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX btm: <http://kbr.be/ns/beltrans/model#>
+PREFIX btid: <http://kbr.be/id/data/> 
+PREFIX bf: <http://id.loc.gov/ontologies/bibframe/>
+PREFIX btisni: <http://kbr.be/isni/>
+PREFIX mads: <http://www.loc.gov/mads/rdf/v1#>
+PREFIX up: <http://users.ugent.be/~tdenies/up/>
+PREFIX marcrel: <http://id.loc.gov/vocabulary/relators/> 
+PREFIX rdagroup1elements: <http://rdvocab.info/Elements/>
+PREFIX rdagroup2elements: <http://rdvocab.info/ElementsGr2/>
+
+
+SELECT
+  ?manifestationID
+    (group_concat(distinct ?authorNameID;SEPARATOR='\n') AS ?authors)
+    (group_concat(distinct ?kbrNameID;SEPARATOR='\n') AS ?kbrNames)
+    (group_concat(distinct ?bnfNameID;SEPARATOR='\n') AS ?bnfNames)
+    (group_concat(distinct ?ntaNameID;SEPARATOR='\n') AS ?ntaNames)
+    (group_concat(distinct ?unescoNameID;SEPARATOR='\n') AS ?unescoNames)
+WHERE {
+
+  graph <http://beltrans-manifestations> {
+    ?manifestation a schema:CreativeWork ;
+                   dcterms:identifier ?manifestationID ;
+                   schema:isPartOf btid:beltransCorpus .
+  }
+
+  # AUTHOR
+  #
+  OPTIONAL {
+    graph <http://beltrans-manifestations> { ?manifestation schema:author ?author . }
+    OPTIONAL { graph <http://beltrans-contributors> { ?author rdfs:label ?authorLabel . } }
+
+    BIND(CONCAT( COALESCE(?authorLabel, "missing name"), " (", ?authorID, ": ", ?authorIdentifiers, ")") as ?authorNameID)
+    # This subquery retrieves the local identifiers of the author
+    {
+      SELECT DISTINCT ?manifestation ?author ?authorID (group_concat(distinct ?authorLocalIdentifier;SEPARATOR=',') as ?authorIdentifiers)
+      WHERE { 
+        graph <http://beltrans-manifestations> {
+          ?manifestation schema:name ?title ;
+                         schema:author ?author .
+        }    
+        ?author dcterms:identifier ?authorID .
+        ?author schema:sameAs/dcterms:identifier ?authorLocalIdentifier . 
+      }
+      group by ?manifestation ?author ?authorID
+    }
+
+    OPTIONAL {
+      graph <http://beltrans-contributors> { ?author schema:sameAs ?kbrURI . }
+      graph <http://kbr-linked-authorities> { ?kbrURI dcterms:identifier ?kbrID . }
+      graph <http://kbr-linked-authorities> { ?kbrURI rdfs:label ?kbrName . }
+
+      BIND( CONCAT(?kbrName, ' (', ?kbrID, ')') AS ?kbrNameID)
+    }
+
+    OPTIONAL {
+      graph <http://beltrans-contributors> { ?author schema:sameAs ?bnfURI . }
+      graph <http://bnf-contributors> { ?bnfURI dcterms:identifier ?bnfID . }
+      graph <http://bnf-contributors> { ?bnfURI foaf:name ?bnfName . }
+
+      BIND( CONCAT(?bnfName, ' (', ?bnfID, ')') AS ?bnfNameID)
+    }
+
+    OPTIONAL {
+      graph <http://beltrans-contributors> { ?author schema:sameAs ?ntaURI . }
+      graph <http://kb-linked-authorities> { ?ntaURI dcterms:identifier ?ntaID . }
+      graph <http://kb-linked-authorities> { ?ntaURI schema:name ?ntaName . }
+
+      BIND( CONCAT(?ntaName, ' (', ?ntaID, ')') AS ?ntaNameID)
+    }
+
+    OPTIONAL {
+      graph <http://beltrans-contributors> { ?author schema:sameAs ?unescoURI . }
+      graph <http://unesco-linked-authorities> { ?unescoURI dcterms:identifier ?unescoID . }
+      graph <http://unesco-linked-authorities> { ?unescoURI rdfs:label ?unescoName . }
+
+      BIND( CONCAT(?unescoName, ' (', ?unescoID, ')') AS ?unescoNameID)
+    }
+
+  }
+}
+GROUP BY ?manifestationID

--- a/data-integration/sparql-queries/get-translator-overlap.sparql
+++ b/data-integration/sparql-queries/get-translator-overlap.sparql
@@ -19,11 +19,11 @@ PREFIX rdagroup2elements: <http://rdvocab.info/ElementsGr2/>
 
 SELECT
   ?manifestationID
-    (group_concat(distinct ?authorNameID;SEPARATOR='\n') AS ?authors)
-    (group_concat(distinct ?kbrNameID;SEPARATOR='\n') AS ?kbrNames)
-    (group_concat(distinct ?bnfNameID;SEPARATOR='\n') AS ?bnfNames)
-    (group_concat(distinct ?ntaNameID;SEPARATOR='\n') AS ?ntaNames)
-    (group_concat(distinct ?unescoNameID;SEPARATOR='\n') AS ?unescoNames)
+    (group_concat(distinct ?translatorNameID;SEPARATOR=';') AS ?translators)
+    (group_concat(distinct ?kbrNameID;SEPARATOR=';') AS ?kbrNames)
+    (group_concat(distinct ?bnfNameID;SEPARATOR=';') AS ?bnfNames)
+    (group_concat(distinct ?ntaNameID;SEPARATOR=';') AS ?ntaNames)
+    (group_concat(distinct ?unescoNameID;SEPARATOR=';') AS ?unescoNames)
 WHERE {
 
   graph <http://beltrans-manifestations> {
@@ -32,37 +32,40 @@ WHERE {
                    schema:isPartOf btid:beltransCorpus .
   }
 
-  # AUTHOR
+  # TRANSLATOR
   #
   OPTIONAL {
-    graph <http://beltrans-manifestations> { ?manifestation schema:author ?author . }
-    OPTIONAL { graph <http://beltrans-contributors> { ?author rdfs:label ?authorLabel . } }
+    graph <http://beltrans-manifestations> { ?manifestation schema:translator ?translator . }
+    OPTIONAL {
+      graph <http://beltrans-contributors> { ?translator rdfs:label ?translatorLabel . } 
+      BIND(REPLACE(?translatorLabel, ";", "", "i") AS ?translatorLabelNorm)
+    }
 
-    BIND(CONCAT( COALESCE(?authorLabel, "missing name"), " (", ?authorID, ": ", ?authorIdentifiers, ")") as ?authorNameID)
-    # This subquery retrieves the local identifiers of the author
+    BIND(CONCAT( COALESCE(?translatorLabelNorm, "missing name"), " (", ?translatorID, ": ", ?translatorIdentifiers, ")") as ?translatorNameID)
+    # This subquery retrieves the local identifiers of the translator
     {
-      SELECT DISTINCT ?manifestation ?author ?authorID (group_concat(distinct ?authorLocalIdentifier;SEPARATOR=',') as ?authorIdentifiers)
+      SELECT DISTINCT ?manifestation ?translator ?translatorID (group_concat(distinct ?translatorLocalIdentifier;SEPARATOR=',') as ?translatorIdentifiers)
       WHERE { 
         graph <http://beltrans-manifestations> {
           ?manifestation schema:name ?title ;
-                         schema:author ?author .
+                         schema:translator ?translator .
         }    
-        ?author dcterms:identifier ?authorID .
-        ?author schema:sameAs/dcterms:identifier ?authorLocalIdentifier . 
+        ?translator dcterms:identifier ?translatorID .
+        ?translator schema:sameAs/dcterms:identifier ?translatorLocalIdentifier . 
       }
-      group by ?manifestation ?author ?authorID
+      GROUP BY ?manifestation ?translator ?translatorID
     }
 
     OPTIONAL {
-      graph <http://beltrans-contributors> { ?author schema:sameAs ?kbrURI . }
+      graph <http://beltrans-contributors> { ?translator schema:sameAs ?kbrURI . }
       graph <http://kbr-linked-authorities> { ?kbrURI dcterms:identifier ?kbrID . }
-      graph <http://kbr-linked-authorities> { ?kbrURI rdfs:label ?kbrName . }
+      graph <http://kbr-linked-authorities> { ?kbrURI rdfs:label|skos:prefLabel ?kbrName . }
 
       BIND( CONCAT(?kbrName, ' (', ?kbrID, ')') AS ?kbrNameID)
     }
 
     OPTIONAL {
-      graph <http://beltrans-contributors> { ?author schema:sameAs ?bnfURI . }
+      graph <http://beltrans-contributors> { ?translator schema:sameAs ?bnfURI . }
       graph <http://bnf-contributors> { ?bnfURI dcterms:identifier ?bnfID . }
       graph <http://bnf-contributors> { ?bnfURI foaf:name ?bnfName . }
 
@@ -70,7 +73,7 @@ WHERE {
     }
 
     OPTIONAL {
-      graph <http://beltrans-contributors> { ?author schema:sameAs ?ntaURI . }
+      graph <http://beltrans-contributors> { ?translator schema:sameAs ?ntaURI . }
       graph <http://kb-linked-authorities> { ?ntaURI dcterms:identifier ?ntaID . }
       graph <http://kb-linked-authorities> { ?ntaURI schema:name ?ntaName . }
 
@@ -78,7 +81,7 @@ WHERE {
     }
 
     OPTIONAL {
-      graph <http://beltrans-contributors> { ?author schema:sameAs ?unescoURI . }
+      graph <http://beltrans-contributors> { ?translator schema:sameAs ?unescoURI . }
       graph <http://unesco-linked-authorities> { ?unescoURI dcterms:identifier ?unescoID . }
       graph <http://unesco-linked-authorities> { ?unescoURI rdfs:label ?unescoName . }
 
@@ -88,3 +91,4 @@ WHERE {
   }
 }
 GROUP BY ?manifestationID
+HAVING(count(?translator) > 1)

--- a/data-integration/utils_string.py
+++ b/data-integration/utils_string.py
@@ -1,4 +1,5 @@
 import unicodedata as ud
+from itertools import combinations
 import re
 
 def normalizeDelimiters(value, delimiter=';'):
@@ -78,8 +79,7 @@ def extractStringFromBrackets(value):
 # -----------------------------------------------------------------------------
 def overlappingValues(values):
   """This function returns true if a value of one array element is also part of another array element.
-  >>> data = ['Jan Janssen', 'Janssen, Jan', 'John Doe']
-  >>> overlappingValues(data)
+  >>> overlappingValues(['Jan Janssen', 'Janssen, Jan', 'John Doe'])
   True
   >>> data1 = ['John Doe', 'Alice', 'Bob', 'Pascal Renard, ']
   >>> overlappingValues(data1)
@@ -88,22 +88,33 @@ def overlappingValues(values):
   The function returns False if an empty array is given
   >>> overlappingValues([])
   False
+
+  An overlap in the same string should NOT be taken into account
+  >>> overlappingValues(['John, John', 'Alice Alice', 'Bob Bobsen'])
+  False
   """
-  lookup = {}
+  lookup = []
+
+  # first create a lookup list per string
   for value in values:
+    lookupValues = set()
     parts = value.replace(',', ' ').split(' ')
     for p in parts:
       namePart = getNormalizedString(p).strip()
       if namePart != '':
-        if namePart in lookup:
-          lookup[namePart] = True
-        else:
-          lookup[namePart] = False
+        lookupValues.add(namePart)
+    lookup.append(lookupValues)
 
-  if True in lookup.values():
-    return True
-  else:
+  if len(lookup) == 0:
     return False
+
+  # we have now a list of sets, e.g. [{'jan', 'janssen'}, {'janssen'}, {'doe'}]
+  # now compare values across the different lookup lists
+  for i in combinations(lookup, 2):
+    if i[0].intersection(i[1]):
+      return True
+
+  return False
 
 # -----------------------------------------------------------------------------
 if __name__ == "__main__":


### PR DESCRIPTION
* Added SPARQL queries and a script to extract possible correlations between contributors of the BELTRANS corpus based on co-authorship (or co-translatorship) in a manifestation
* The generated correlation lists can be used to enrich the RDF representation of, among others, Unesco Index Translationum authorities. Therefore this pull request will fix #174 