### PR TITLE
Added more information about publishers to fix #209

### DIFF
--- a/data-integration/dataprofile-aggregated.sparql
+++ b/data-integration/dataprofile-aggregated.sparql
@@ -41,7 +41,7 @@ PREFIX rdagroup2elements: <http://rdvocab.info/ElementsGr2/>
     (group_concat(distinct ?illustratorNameID;SEPARATOR=';') AS ?illustratorIdentifiers)
     (group_concat(distinct ?scenaristNameID;SEPARATOR=';') AS ?scenaristIdentifiers)
     (group_concat(distinct ?publishingDirectorNameID;SEPARATOR=';') AS ?publishingDirectorIdentifiers)
-    (group_concat(distinct ?publisherNameID;SEPARATOR=';') AS ?publisherIdentifiers)
+    (group_concat(distinct ?publisherNameID;SEPARATOR=';') AS ?targetPublisherIdentifiers)
 
     (group_concat(distinct ?kbrManifestationID;SEPARATOR=';') AS ?targetKBRIdentifier)
     (group_concat(distinct ?bnfManifestationID;SEPARATOR=';') AS ?targetBnFIdentifier)
@@ -52,6 +52,7 @@ PREFIX rdagroup2elements: <http://rdvocab.info/ElementsGr2/>
     (group_concat(distinct ?kbrSourceManifestationID;SEPARATOR=';') AS ?sourceKBRIdentifier)
     (group_concat(distinct ?kbrSourceManifestationISBN10;SEPARATOR=';') AS ?sourceISBN10)
     (group_concat(distinct ?kbrSourceManifestationISBN13;SEPARATOR=';') AS ?sourceISBN13)
+    ("" AS ?sourcePublisherIdentifiers)
 
     (group_concat(distinct ?kbrTargetManifestationEdition;SEPARATOR=';') AS ?targetKBREdition)
     (group_concat(distinct ?bnfTargetManifestationEdition;SEPARATOR=';') AS ?targetBnFEdition)

--- a/data-integration/dataprofile-contributors-orgs.sparql
+++ b/data-integration/dataprofile-contributors-orgs.sparql
@@ -28,7 +28,7 @@ SELECT DISTINCT
   (group_concat(distinct ?wikidata;SEPARATOR=';') AS ?wikidataIDs)
 WHERE {
 
-  graph <http://beltrans-manifestations> { ?manifestation schema:author|schema:translator|marcrel:ill|marcrel:sce|marcrel:pbd ?contributorURI . }
+  graph <http://beltrans-manifestations> { ?manifestation schema:author|schema:translator|schema:publisher|marcrel:ill|marcrel:sce|marcrel:pbd ?contributorURI . }
 
   graph <http://beltrans-contributors> {
     ?contributorURI a schema:Organization ;

--- a/data-integration/integrate-data.sh
+++ b/data-integration/integrate-data.sh
@@ -259,7 +259,9 @@ SUFFIX_DATA_PROFILE_CONT_PERSONS_ALL_DATA_FILE="contributors-persons-all-info.cs
 SUFFIX_DATA_PROFILE_CONT_PERSONS_ALL_DATA_FILE_SORTED="contributors-persons-all-info-sorted.csv"
 SUFFIX_DATA_PROFILE_CONT_PERSONS_FILE="contributors-persons.csv"
 SUFFIX_DATA_PROFILE_CONT_ALL_PERSONS="all-persons.csv"
+SUFFIX_DATA_PROFILE_CONT_ALL_ORGS="all-orgs.csv"
 SUFFIX_DATA_PROFILE_CONT_ORGS_FILE="contributors-orgs.csv"
+SUFFIX_DATA_PROFILE_CONT_ORGS_FILE_PROCESSED="contributors-orgs-processed.csv"
 SUFFIX_DATA_PROFILE_FILE_KBR="integrated-data-kbr-not-filtered.csv"
 SUFFIX_DATA_PROFILE_FILE_BNF="integrated-data-bnf-not-filtered.csv"
 SUFFIX_DATA_PROFILE_CONT_BE_FILE="integrated-data-contributors-belgian-not-filtered.csv"
@@ -923,7 +925,9 @@ function postprocess {
   tmp1="$integrationName/csv/kbr-enriched-not-yet-bnf-and-kb.csv"
   tmp2="$integrationName/csv/kbr-and-bnf-enriched-not-yet-kb.csv"
 
-  contributorsOrgs="$integrationName/csv/$SUFFIX_DATA_PROFILE_CONT_ORGS_FILE"
+  contributorsOrgsAllData="$integrationName/csv/$SUFFIX_DATA_PROFILE_CONT_ORGS_FILE"
+  contributorsOrgs="$integrationName/csv/$SUFFIX_DATA_PROFILE_CONT_ORGS_FILE_PROCESSED"
+  allOrgs="$integrationName/csv/$SUFFIX_DATA_PROFILE_CONT_ALL_ORGS"
 
   kbCodeHierarchy="$integrationName/csv/$SUFFIX_DATA_PROFILE_KBCODE"
 
@@ -952,11 +956,17 @@ function postprocess {
   time python -m $MODULE_POSTPROCESS_SORT_COLUMN_VALUES -i $contributorsPersonsAllData -o $contributorsPersonsAllDataSorted \
        -c "nationalities" -c "gender"
 
-  echo "Postprocess contributor data ..."
-  time python $SCRIPT_POSTPROCESS_QUERY_CONT_RESULT -c $contributorsPersonsAllDataSorted -m $integratedDataEnriched -o $contributorsPersons
+  echo "Postprocess contributor data - persons ..."
+  time python $SCRIPT_POSTPROCESS_QUERY_CONT_RESULT -c $contributorsPersonsAllDataSorted -m $integratedDataEnriched -o $contributorsPersons -t "persons"
 
-  echo "Postprocess contributor data (keep non-contributors)..."
-  time python $SCRIPT_POSTPROCESS_QUERY_CONT_RESULT -c $contributorsPersonsAllDataSorted -m $integratedDataEnriched -o $allPersons --keep-non-contributors
+  echo "Postprocess contributor data - orgs ..."
+  time python $SCRIPT_POSTPROCESS_QUERY_CONT_RESULT -c $contributorsOrgsAllData -m $integratedDataEnriched -o $contributorsOrgs -t "orgs"
+
+  echo "Postprocess contributor data -persons (keep non-contributors)..."
+  time python $SCRIPT_POSTPROCESS_QUERY_CONT_RESULT -c $contributorsPersonsAllDataSorted -m $integratedDataEnriched -o $allPersons --keep-non-contributors -t "persons"
+
+  echo "Postprocess contributor data - orgs (keep non-contributors)..."
+  time python $SCRIPT_POSTPROCESS_QUERY_CONT_RESULT -c $contributorsOrgsAllData -m $integratedDataEnriched -o $allOrgs --keep-non-contributors -t "orgs"
 
   echo "Sort certain columns in the manifestation CSV"
   time python -m $MODULE_POSTPROCESS_SORT_COLUMN_VALUES -i $integratedDataEnriched -o $integratedDataEnrichedSorted \
@@ -964,7 +974,7 @@ function postprocess {
 
 
   echo "Create Excel sheet for data ..."
-  time python $SCRIPT_CSV_TO_EXCEL $integratedDataEnrichedSorted $contributorsPersons $contributorsOrgs $placeOfPublicationsGeonames $allPersons $kbCodeHierarchy -s "translations" -s "person contributors" -s "org contributors" -s "geonames" -s "all persons" -s "KBCode" -o $excelData
+  time python $SCRIPT_CSV_TO_EXCEL $integratedDataEnrichedSorted $contributorsPersons $contributorsOrgs $placeOfPublicationsGeonames $allPersons $allOrgs $kbCodeHierarchy -s "translations" -s "person contributors" -s "org contributors" -s "geonames" -s "all persons" -s "all orgs" -s "KBCode" -o $excelData
 
 }
 

--- a/data-integration/post-process-contributors.py
+++ b/data-integration/post-process-contributors.py
@@ -17,6 +17,7 @@ def main():
   parser.add_option('-c', '--input-contributors', action='store', help='The input file containing CSV data with one contributor per line')
   parser.add_option('-m', '--input-manifestations', action='store', help='The input file containing CSV data with one manifestation per line')
   parser.add_option('-o', '--output-file', action='store', help='The file in which content with new headers is stored')
+  parser.add_option('-t', '--contributor-type', action='store', help='The type of contributor to postprocess, valid values are "persons" or "orgs"')
   parser.add_option('--keep-non-contributors', action='store_true', default=False, help='If this flag is set, contributors with 0 authored,translated etc books are not filtered out')
   (options, args) = parser.parse_args()
 
@@ -27,6 +28,11 @@ def main():
     parser.print_help()
     exit(1)
 
+  if options.contributor_type != 'persons' and options.contributor_type != 'orgs':
+    print(f'Unknown contributor type "{options.contributor_type}", it should be persons or orgs')
+    parser.print_help()
+    exit(1)
+
   with open(options.input_contributors, 'r', encoding="utf-8") as inFileContributors, \
        open(options.input_manifestations, 'r', encoding="utf-8") as inFileManifestations, \
        open(options.output_file, 'w', encoding="utf-8") as outFile:
@@ -34,16 +40,17 @@ def main():
     contributorsReader = csv.DictReader(inFileContributors, delimiter=',')
     headers = contributorsReader.fieldnames.copy()
 
-    # In the output we only want a single birth date and a single death date column
-    # thus first remove the respective columns from different data sources
-    headersToRemove = ['birthDateKBR', 'deathDateKBR', 'birthDateBnF', 'deathDateBnF', 'birthDateNTA', 'deathDateNTA', 'birthDateISNI', 'deathDateISNI']
+    if options.contributor_type == 'persons':
+      # In the output we only want a single birth date and a single death date column
+      # thus first remove the respective columns from different data sources
+      headersToRemove = ['birthDateKBR', 'deathDateKBR', 'birthDateBnF', 'deathDateBnF', 'birthDateNTA', 'deathDateNTA', 'birthDateISNI', 'deathDateISNI']
 
-    for r in headersToRemove:
-      headers.remove(r)
+      for r in headersToRemove:
+        headers.remove(r)
 
-    # and then add the single columns we want
-    headers.insert(3, 'birthDate')
-    headers.insert(4, 'deathDate')
+      # and then add the single columns we want
+      headers.insert(3, 'birthDate')
+      headers.insert(4, 'deathDate')
 
     # similarly, add columns for statistics we will add
     headers.insert(5, 'authorIn')
@@ -52,6 +59,10 @@ def main():
     headers.insert(8, 'scenaristIn')
     headers.insert(9, 'publishingDirectorIn')
 
+    if options.contributor_type == 'orgs':
+      headers.insert(10, 'publishedTranslationOf')
+      headers.insert(11, 'publishedOriginalOf')
+
     outputWriter = csv.DictWriter(outFile, delimiter=',', quotechar='"', quoting=csv.QUOTE_MINIMAL, fieldnames=headers)
     outputWriter.writeheader()
 
@@ -59,33 +70,43 @@ def main():
     sources = ['KBR', 'BnF', 'NTA', 'ISNI']
     mismatchLog = {}
 
-    contributions = {'authors': {}, 'translators': {}, 'illustrators': {}, 'scenarists': {}, 'publishingDirectors': {}}
+    contributions = {'authors': {}, 'translators': {}, 'illustrators': {}, 'scenarists': {}, 'publishingDirectors': {}, 'publishersTranslation': {}, 'publishersOriginal': {}}
     manifestationsReader = csv.DictReader(inFileManifestations, delimiter=',')
     for row in manifestationsReader:
-      utils_stats.countContribution(row['authorIdentifiers'], contributions['authors'])
-      utils_stats.countContribution(row['translatorIdentifiers'], contributions['translators'])
-      utils_stats.countContribution(row['illustratorIdentifiers'], contributions['illustrators'])
-      utils_stats.countContribution(row['scenaristIdentifiers'], contributions['scenarists'])
-      utils_stats.countContribution(row['publishingDirectorIdentifiers'], contributions['publishingDirectors'])
+      utils_stats.countContributionBasedOnIdentifier(row['authorIdentifiers'], contributions['authors'])
+      utils_stats.countContributionBasedOnIdentifier(row['translatorIdentifiers'], contributions['translators'])
+      utils_stats.countContributionBasedOnIdentifier(row['illustratorIdentifiers'], contributions['illustrators'])
+      utils_stats.countContributionBasedOnIdentifier(row['scenaristIdentifiers'], contributions['scenarists'])
+      utils_stats.countContributionBasedOnIdentifier(row['publishingDirectorIdentifiers'], contributions['publishingDirectors'])
+
+      if options.contributor_type == 'orgs': 
+        utils_stats.countContributionBasedOnIdentifier(row['targetPublisherIdentifiers'], contributions['publishersTranslation'])
+        utils_stats.countContributionBasedOnIdentifier(row['sourcePublisherIdentifiers'], contributions['publishersOriginal'])
 
     # write relevant data to output
     for row in contributorsReader:
       rowID = row['contributorID']
       contributorName = row['name']
 
-      # add a single column for birth date respectively death date
-      utils_date.selectDate(row, 'birthDate', sources, 'contributorID', mismatchLog, 'date')
-      utils_date.selectDate(row, 'deathDate', sources, 'contributorID', mismatchLog, 'date')
+      if options.contributor_type == 'persons':
+        # add a single column for birth date respectively death date
+        utils_date.selectDate(row, 'birthDate', sources, 'contributorID', mismatchLog, 'date')
+        utils_date.selectDate(row, 'deathDate', sources, 'contributorID', mismatchLog, 'date')
 
-      if contributorName != '':
-        contributorName = contributorName.strip()
+      if rowID != '':
         # add statistics about how many manifestations the contributor contributed to
         # manifestation data is looked up using the provided manifestations file residing in a Pandas dataframe
-        numberAuthored = contributions['authors'][contributorName] if contributorName in contributions['authors'] else 0
-        numberTranslated = contributions['translators'][contributorName] if contributorName in contributions['translators'] else 0
-        numberIllustrated = contributions['illustrators'][contributorName] if contributorName in contributions['illustrators'] else 0
-        numberScened = contributions['scenarists'][contributorName] if contributorName in contributions['scenarists'] else 0
-        numberDirected = contributions['publishingDirectors'][contributorName] if contributorName in contributions['publishingDirectors'] else 0
+        numberAuthored = contributions['authors'][rowID] if rowID in contributions['authors'] else 0
+        numberTranslated = contributions['translators'][rowID] if rowID in contributions['translators'] else 0
+        numberIllustrated = contributions['illustrators'][rowID] if rowID in contributions['illustrators'] else 0
+        numberScened = contributions['scenarists'][rowID] if rowID in contributions['scenarists'] else 0
+        numberDirected = contributions['publishingDirectors'][rowID] if rowID in contributions['publishingDirectors'] else 0
+
+        if options.contributor_type == 'orgs':
+          numberPublishedTranslation = contributions['publishersTranslation'][rowID] if rowID in contributions['publishersTranslation'] else 0
+          numberPublishedOriginal = contributions['publishersOriginal'][rowID] if rowID in contributions['publishersOriginal'] else 0
+          row['publishedTranslationOf'] = numberPublishedTranslation
+          row['publishedOriginalOf'] = numberPublishedOriginal
 
         row['authorIn'] = numberAuthored
         row['translatorIn'] = numberTranslated
@@ -98,14 +119,25 @@ def main():
         row['illustratorIn'] = 0
         row['scenaristIn'] = 0
         row['publishingDirectorIn'] = 0
+        if options.contributor_type == 'orgs':
+          row['publishedTranslationOf'] = 0
+          row['publishedOriginalOf'] = 0
 
       if options.keep_non_contributors:
         outputWriter.writerow(row)
       else:
-        if row['authorIn'] > 0 or row['translatorIn'] > 0\
-                or row['illustratorIn'] > 0 or row['scenaristIn'] > 0\
-                or row['publishingDirectorIn'] > 0:
-          outputWriter.writerow(row)
+        if options.contributor_type == 'orgs':
+          if row['authorIn'] > 0 or row['translatorIn'] > 0\
+                  or row['illustratorIn'] > 0 or row['scenaristIn'] > 0\
+                  or row['publishingDirectorIn'] > 0\
+                  or row['publishedTranslationOf'] >0\
+                  or row['publishedOriginalOf'] >0:
+            outputWriter.writerow(row)
+        else:
+          if row['authorIn'] > 0 or row['translatorIn'] > 0\
+                  or row['illustratorIn'] > 0 or row['scenaristIn'] > 0\
+                  or row['publishingDirectorIn'] > 0:
+            outputWriter.writerow(row)
 
   # print statistics
   for dateType in mismatchLog:

--- a/data-integration/utils_stats.py
+++ b/data-integration/utils_stats.py
@@ -2,6 +2,7 @@ import pandas as pd
 import numpy as np
 from datetime import datetime
 import os
+import re
 
 # -----------------------------------------------------------------------------
 def countRowsWithValueForColumn(df, column):
@@ -261,6 +262,56 @@ def getContributorName(nameIDString):
   """
   contributorName = nameIDString.split('(')[0] if '(' in nameIDString else nameIDString
   return contributorName.strip()
+
+# -----------------------------------------------------------------------------
+def getContributorID(nameIDString):
+  """
+  >>> getContributorID('Lieber, Sven (123)')
+  '123'
+  >>> getContributorID('Lieber, Sven ')
+  ''
+  """
+  if '(' in nameIDString:
+    contributorIDs = re.findall(r'\((.*)\)', nameIDString)
+    if len(contributorIDs) > 0:
+      contributorID = contributorIDs[0]
+    else:
+      contributorID = ''
+  else:
+    contributorID = ''
+  return contributorID.strip()
+
+
+
+# -----------------------------------------------------------------------------
+def countContributionBasedOnIdentifier(value, counter, valueDelimiter=';'):
+  """This function counts contributors.
+  >>> counter = {}
+  >>> countContributionBasedOnIdentifier('Lieber, Sven (123)', counter)
+  >>> counter['123']
+  1
+  >>> countContributionBasedOnIdentifier('Sven Lieber (456)', counter)
+  >>> counter['456']
+  1
+  >>> countContributionBasedOnIdentifier('Lieber, Sven (123)', counter)
+  >>> counter['123']
+  2
+  >>> countContributionBasedOnIdentifier('"_$C(128)_"y!"_$C(138,139"', counter)
+  >>> counter['128']
+  1
+  """
+  if value != '':
+    contributors = value.split(valueDelimiter) if valueDelimiter in value else [value]
+    alreadyProcessed = set()
+    for c in contributors:
+      contributorName = getContributorID(c)
+      if contributorName not in alreadyProcessed:
+        alreadyProcessed.add(contributorName)
+        if contributorName in counter:
+          counter[contributorName] = counter[contributorName] + 1
+        else:
+          counter[contributorName] = 1
+
 
 # -----------------------------------------------------------------------------
 def countContribution(value, counter, valueDelimiter=';'):


### PR DESCRIPTION
* The sheet org-contributors now also contains statistics about how often the org published a translation or an original (the original count is 0 for now). 
* Additionally, all organizations are listed in the new sheet all-orgs. 
* The post-process script was adapted to also handle organizations. The changes are a bit hacky, the script would profit from some refactoring to be more modular, or by splitting the script into two scripts reusing modular functions.